### PR TITLE
Bug fix for paired-end mode

### DIFF
--- a/Wessim_ver_1.0/Wessim1.py
+++ b/Wessim_ver_1.0/Wessim1.py
@@ -102,10 +102,14 @@ def main(argv):
 	for t in range(0, threadnumber):
 		readstart = int(float(readnumber) / float(threadnumber) * t) + 1
 		readend = int(float(readnumber) / float(threadnumber) * (t+1))
+
+		# Sub-command for __sub_wessim1.py
 		command = "python2 " + cur_script_path + "/" "__sub_wessim1.py " + arguline + " -1 " + str(readstart) + " -2 " + str(readend) + " -i " + str(t+1)
+		print command
 		p = Process(target=subprogram, args=(command, t+1))
 		p.start()
 		processes.append(p)
+
 	for p in processes:
 		p.join()
 	t1 = time()


### PR DESCRIPTION
This PR fixes a bug in the simulation of paired-end reads when using the "ideal target" approach. The fix allows us for the random selection of a DNA fragment inside the target region.