### PR TITLE
Remove reference argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,23 @@ There are two main scripts in the package - Wessim1.py and Wessim2.py. You will 
 The basic synopsis of Wessim1 is like below:
 <pre><code>
 # Run Wessim1 in ideal target mode
->python Wessim1.py -R ref.fa -B target.bed -n 1000000 -l 100 -M model.gzip -z -o result -t 4
-</code></pre> 
+#
+# -n: Number of reads
+# -l: Length of reads
+# -m: Error model
+# -o: Output prefix
+# -t: Number of threads/cores.
+./Wessim1.py \
+    --target-fasta-file target_reference.fa \
+    --target-abd-file target_reference.abd
+    -n 1000000 \
+    -l 100 \
+    -M model.gzip \
+    -z \
+    -o result \
+    -t 4
+```
+
 This will generate *result.fastq.gz* (single-end mode / gzip compressed) using 4 threads (CPU cores).
 
 For Wessim2:

--- a/Wessim_ver_1.0/Wessim1.py
+++ b/Wessim_ver_1.0/Wessim1.py
@@ -25,7 +25,6 @@ def main(argv):
 	parser = argparse.ArgumentParser(description='Wessim1: Whole Exome Sequencing SIMulator 1 (Ideal target region-based version)', prog='Wessim1', formatter_class=argparse.RawTextHelpFormatter)
 
 	group1 = parser.add_argument_group('Mandatory input files')
-	group1.add_argument('-R', metavar = 'FILE', dest='reference', required=True, help='faidx-indexed (R)eference genome FASTA file')
 	group1.add_argument(
 		"--target-fasta-file",
 		help = "The target FASTA file generated from get_region_vector.py",
@@ -58,7 +57,6 @@ def main(argv):
 	group4.add_argument('--read-name-prefix', dest='read_name_prefix', default = '_from_', required=False, help='Prefix to add to simulated read names (default: "%(default)s")')
 
 	args = parser.parse_args()
-	reffile = args.reference
 
 	isize = args.fragsize
 	isd = args.fragsd
@@ -89,7 +87,6 @@ def main(argv):
 
 	print
 	print "-------------------------------------------"
-	print "Reference:", reffile
 	print "Target FASTA file:", args.target_fasta_file
 	print "Target ABD file:", args.target_abd_file
 	print "Fragment:",isize, "+-", isd, ">", imin

--- a/Wessim_ver_1.0/__sub_wessim1.py
+++ b/Wessim_ver_1.0/__sub_wessim1.py
@@ -17,7 +17,6 @@ def main(argv):
 	parser = argparse.ArgumentParser(description='sub-wessim: a sub-program for Wessim1. (NOTE!) Do not run this program. Use "Wessim1.py" instead. ', prog='wessim1_sub', formatter_class=argparse.RawTextHelpFormatter)
 
 	group1 = parser.add_argument_group('Mandatory input files')
-	group1.add_argument('-R', metavar = 'FILE', dest='reference', required=True, help='(R)eference genome FASTA file')
 	group1.add_argument(
 		"--target-fasta-file",
 		help = "The target FASTA file generated from get_region_vector.py",
@@ -53,7 +52,6 @@ def main(argv):
 	group4.add_argument('--read-name-prefix', dest='read_name_prefix', default = '_from_', required=False, help='Prefix to add to simulated read names (default: "%(default)s")')
 
 	args = parser.parse_args()
-	reffile = args.reference
 	faoutfile = args.target_fasta_file
 	abdoutfile = args.target_abd_file
 


### PR DESCRIPTION
This PR removes the reference argument (-R) from the call of `Wessim1.py` since it has been moved to the `get_region_vector.py` script now.